### PR TITLE
Fixed `DiscoveryParser` for address without port

### DIFF
--- a/src/main/java/be/teletask/onvif/parsers/DiscoveryParser.java
+++ b/src/main/java/be/teletask/onvif/parsers/DiscoveryParser.java
@@ -119,7 +119,7 @@ public class DiscoveryParser extends OnvifParser<List<Device>> {
 
         for (String address : uris) {
             final URI url = URI.create(address);
-            final String parsedAddress = url.getScheme() + "://" + url.getHost() + (url.getPort() == 0 ? "" : ":" + url.getPort());
+            final String parsedAddress = url.getScheme() + "://" + url.getHost() + (url.getPort() == 0 || url.getPort() == -1 ? "" : ":" + url.getPort());
 
             OnvifDevice device = new OnvifDevice(parsedAddress);
             if (uriAndScopes.getScopes() != null) {


### PR DESCRIPTION

`URI.getPort()` will return `-1` for an URI without a port. This is not handled in the `DiscoveryParser` and results in an incorrect parsed url. For example: `http://192.168.1.108:-1` instead of the correct `http://192.168.1.108`.

This PR will fix the parsing.