### PR TITLE
Use timestamp in UTC during authentication

### DIFF
--- a/src/main/java/be/teletask/onvif/OnvifXMLBuilder.java
+++ b/src/main/java/be/teletask/onvif/OnvifXMLBuilder.java
@@ -7,6 +7,7 @@ import com.burgstaller.okhttp.digest.DigestAuthenticator;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -35,7 +36,7 @@ public class OnvifXMLBuilder {
                 byte[] bytes = new byte[20];
                 new Random().nextBytes(bytes);
                 nonce = Base64.getEncoder().encodeToString(bytes);
-                created = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+                created = Instant.now().toString(); // Timestamp in UTC formatted like: 2022-11-05T12:18:19.600710800Z
 
                 byte[] createdByteArray = created.getBytes(StandardCharsets.UTF_8);
                 byte[] passwordByteArray = cred.getPassword().getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/be/teletask/onvif/OnvifXMLBuilder.java
+++ b/src/main/java/be/teletask/onvif/OnvifXMLBuilder.java
@@ -2,16 +2,11 @@ package be.teletask.onvif;
 
 
 import com.burgstaller.okhttp.digest.Credentials;
-import com.burgstaller.okhttp.digest.DigestAuthenticator;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.Random;
 


### PR DESCRIPTION
According the [ONVIF Application Programmer's Guide](http://www.onvif.org/wp-content/uploads/2016/12/ONVIF_WG-APG-Application_Programmers_Guide-1.pdf), the timestamp used during authentication needs to be in UTC. This PR fixes this and resolves the authentication problems I had with cameras from Dahua and TP-link.